### PR TITLE
Migrate to AGP 8.x with Gradle 8.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 
 plugins {
-    id "com.android.application" version "7.4.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
+    id "com.android.application" version "8.3.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.23" apply false
 }
 
 task clean(type: Delete) {

--- a/example_app/build.gradle
+++ b/example_app/build.gradle
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace = "io.scanbot.example.sdk.barcode"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "io.scanbot.example.sdk.barcode.android"
-        targetSdk = 30
+        targetSdk = 33
         minSdk = 21
 
         versionCode = 1
@@ -18,14 +18,22 @@ android {
     }
 
     buildTypes {
+        debug {
+            minifyEnabled = false
+            shrinkResources = false
+            debuggable = true
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+        }
         release {
-            minifyEnabled true
+            minifyEnabled = true
+            shrinkResources = true
+            debuggable = true
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 
     buildFeatures {
@@ -34,7 +42,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.4"
+        kotlinCompilerExtensionVersion = "1.5.12"
     }
 }
 
@@ -50,5 +58,5 @@ dependencies {
     implementation("io.scanbot:rtu-ui-v2-barcode:$sdkVersion")
     implementation("io.scanbot:barcode-sdk-pdfium:$sdkVersion")
 
-    implementation("com.google.android.material:material:1.9.0")
+    implementation("com.google.android.material:material:1.11.0")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 
    repositories {
-      mavenLocal() // TODO: remove
+//      mavenLocal() // for dev-use only, do NOT commit!
       google()
       mavenCentral()
 


### PR DESCRIPTION
DO NOT MERGE
We don't want to force repo users to update to the latest AndroidStudio (AGP 8.x needs it)

DO NOT CLOSE
Keep this branch for possible R8 issues investigation